### PR TITLE
Add ES6 Module Support.

### DIFF
--- a/dist/jquery.gifplayer.js
+++ b/dist/jquery.gifplayer.js
@@ -5,7 +5,13 @@
 * Released under the MIT license
 */
 
-(function($) {
+(function (factory) {
+  if(typeof module === "object" && typeof module.exports === "object") {
+    module.exports = factory(require("jquery"));
+  } else {
+    factory(jQuery);
+  }
+}(function($) {
 
 	function GifPlayer(preview, options){
 		this.previewElement = preview;
@@ -360,4 +366,6 @@
 		onLoadComplete: function(){}
 	};
 
-})(jQuery);
+	return GifPlayer;
+
+}));


### PR DESCRIPTION
Hi @rubentd ,

First of all, thanks for publishing on npm so quickly (#25).

With this PR now everyone can use it with ES6 or CommonJS modules like this:

```js
import $ from 'jquery';
import gifplayer from 'gifplayer';

$('.gifplayer').gifplayer();
```

or this:

```js
var $ = require('jquery');
var gifplayer = require('gifplayer');

$('.gifplayer').gifplayer();
```

It's been tested and works very well with both scenarios. Also it works with the old way, so nothing will break after this change.

As a reference I used this article: http://blog.npmjs.org/post/112712169830/making-your-jquery-plugin-work-better-with-npm 