### PR TITLE
Add onClick event

### DIFF
--- a/dist/jquery.gifplayer.js
+++ b/dist/jquery.gifplayer.js
@@ -81,10 +81,14 @@
 						gp.previewElement.trigger('click');
 					});
 					gp.previewElement.on( 'click', function(e){
+						// Fire event onClick
+						gp.getOption('onClick').call(gp.previewElement, e);
+
 						gp.loadAnimation();
 						e.preventDefault();
 						e.stopPropagation();
 					});
+
 					break;
 				case 'hover':
 					gp.previewElement.on( 'click mouseover', function(e){
@@ -194,6 +198,9 @@
 			this.gifElement.css('left','0');
 			this.gifElement.attr('src', gifSrc);
 			this.gifElement.click( function(e){
+				// Fire event onClick
+				gp.getOption('onClick').call(gp.previewElement, e);
+
 				$(this).remove();
 				gp.stopGif();
 				e.preventDefault();
@@ -362,6 +369,7 @@
 		scope: false,
 		onPlay: function(){},
 		onStop: function(){},
+		onClick: function(){},
 		onLoad: function(){},
 		onLoadComplete: function(){}
 	};

--- a/src/gifplayer.js
+++ b/src/gifplayer.js
@@ -81,10 +81,14 @@
 						gp.previewElement.trigger('click');
 					});
 					gp.previewElement.on( 'click', function(e){
+						// Fire event onClick
+						gp.getOption('onClick').call(gp.previewElement, e);
+
 						gp.loadAnimation();
 						e.preventDefault();
 						e.stopPropagation();
 					});
+
 					break;
 				case 'hover':
 					gp.previewElement.on( 'click mouseover', function(e){
@@ -194,6 +198,9 @@
 			this.gifElement.css('left','0');
 			this.gifElement.attr('src', gifSrc);
 			this.gifElement.click( function(e){
+				// Fire event onClick
+				gp.getOption('onClick').call(gp.previewElement, e);
+
 				$(this).remove();
 				gp.stopGif();
 				e.preventDefault();
@@ -362,6 +369,7 @@
 		scope: false,
 		onPlay: function(){},
 		onStop: function(){},
+		onClick: function(){},
 		onLoad: function(){},
 		onLoadComplete: function(){}
 	};


### PR DESCRIPTION
This commit/PR adds an onClick event. This event fires after the user clicks on the element, and **before** the animation is started/stopped. It does **not** modify the preventDefault() and stopPropagation() behavior. I use this for enabling a second click to take the user to a specific URL, but it could be used for any purpose.

Usage

```
$('img').gifplayer({
    onClick: function(e) {
        console.log('click event', e);
    }
});

```