### PR TITLE
Re #20: Preload bug jquery 3.0

### DIFF
--- a/dist/jquery.gifplayer.js
+++ b/dist/jquery.gifplayer.js
@@ -176,14 +176,14 @@
 			var wait = this.getOption('wait');
 			if(wait){
 				//Wait until gif loads
-				this.gifElement.load( function(){
+				this.gifElement.on({ load: function(){
 					gp.animationLoaded = true;
 					gp.resetEvents();
 					gp.previewElement.hide();
 					gp.wrapper.append(gp.gifElement);
 					gp.spinnerElement.hide();
 					gp.getOption('onLoadComplete').call(gp.previewElement);
-				});
+				}});
 			}else{
 				//Try to show gif instantly
 				gp.animationLoaded = true;

--- a/src/gifplayer.js
+++ b/src/gifplayer.js
@@ -176,14 +176,14 @@
 			var wait = this.getOption('wait');
 			if(wait){
 				//Wait until gif loads
-				this.gifElement.load( function(){
+				this.gifElement.on({ load: function(){
 					gp.animationLoaded = true;
 					gp.resetEvents();
 					gp.previewElement.hide();
 					gp.wrapper.append(gp.gifElement);
 					gp.spinnerElement.hide();
 					gp.getOption('onLoadComplete').call(gp.previewElement);
-				});
+				}});
 			}else{
 				//Try to show gif instantly
 				gp.animationLoaded = true;


### PR DESCRIPTION
In reference to ticket #20 by @walterfaas

I confirm I was having the same exact problem, only if using `{wait: true}`, on jQuery 3.2.1

Fix works, and is documented in the stackoverflow question linked by OP.

OP never created a PR, so I went ahead and did so. Credit goes to @walterfaas