### PR TITLE
Re #35: stopGif() before .animationLoaded results in UI bug

### DIFF
--- a/dist/jquery.gifplayer.js
+++ b/dist/jquery.gifplayer.js
@@ -135,11 +135,15 @@
 		},
 
 		stopGif: function(){
-			this.gifElement.hide();
-			this.previewElement.show();
-			this.playElement.show();
-			this.resetEvents();
-			this.getOption('onStop').call(this.previewElement);
+			if (this.animationLoaded) {
+				this.gifElement.hide();
+				this.previewElement.show();
+				this.playElement.show();
+				this.resetEvents();
+				this.getOption('onStop').call(this.previewElement);
+			}else{
+				this.abortLoading();
+			}
 		},
 
 		getFile: function( ext ){
@@ -292,8 +296,10 @@
 		abortLoading: function(e){
 			this.spinnerElement.hide();
 			this.playElement.show();
-			e.preventDefault();
-			e.stopPropagation();
+			if (typeof e !== 'undefined') {
+				e.preventDefault();
+				e.stopPropagation();
+			}
 			this.gifElement.off('load').on( 'load', function(ev){
 				ev.preventDefault();
 				ev.stopPropagation();

--- a/src/gifplayer.js
+++ b/src/gifplayer.js
@@ -135,11 +135,15 @@
 		},
 
 		stopGif: function(){
-			this.gifElement.hide();
-			this.previewElement.show();
-			this.playElement.show();
-			this.resetEvents();
-			this.getOption('onStop').call(this.previewElement);
+			if (this.animationLoaded) {
+				this.gifElement.hide();
+				this.previewElement.show();
+				this.playElement.show();
+				this.resetEvents();
+				this.getOption('onStop').call(this.previewElement);
+			}else{
+				this.abortLoading();
+			}
 		},
 
 		getFile: function( ext ){
@@ -292,8 +296,10 @@
 		abortLoading: function(e){
 			this.spinnerElement.hide();
 			this.playElement.show();
-			e.preventDefault();
-			e.stopPropagation();
+			if (typeof e !== 'undefined') {
+				e.preventDefault();
+				e.stopPropagation();
+			}
 			this.gifElement.off('load').on( 'load', function(ev){
 				ev.preventDefault();
 				ev.stopPropagation();


### PR DESCRIPTION
Re #35: stopGif() before .animationLoaded results in UI bug

Check if `animationLoaded` is true. If so, execute script as usual. If not, call `abortLoading()` instead.

Also requires that `abortLoading()` be able to execute without an event `e` passed to it, since there is no event related to this action.